### PR TITLE
feat: add useStacQuery declarative search hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,69 @@ function StacComponent() {
 }
 ```
 
+### useStacQuery
+
+A declarative search hook that runs automatically whenever `payload` changes. Unlike `useStacSearch`, there is no `submit()` call — the query fires as soon as `stacApi` is available and re-runs on every payload change.
+
+Use this hook when you want data-bound search (e.g., filters wired to component state or URL params that should immediately reflect results). Use `useStacSearch` when you need explicit user control over when searches execute.
+
+#### Initialization
+
+```js
+import { useStacQuery } from 'stac-react';
+const { results } = useStacQuery(payload);
+```
+
+#### Parameters
+
+| Option    | Type            | Description                                                             |
+| --------- | --------------- | ----------------------------------------------------------------------- |
+| `payload` | `SearchPayload` | Search parameters. The query re-runs whenever this value changes.       |
+
+`SearchPayload` fields:
+
+| Field         | Type            | Description                                                    |
+| ------------- | --------------- | -------------------------------------------------------------- |
+| `collections` | `string[]`      | Collection IDs to filter by.                                   |
+| `bbox`        | `number[]`      | Bounding box `[minLon, minLat, maxLon, maxLat]`.               |
+| `dateRange`   | `object`        | Date range with optional `from` and `to` ISO date strings.     |
+| `ids`         | `string[]`      | Item IDs to filter by.                                         |
+| `sortby`      | `Sortby[]`      | Array of `{ field, direction }` sort specifications.           |
+
+#### Return values
+
+| Option       | Type              | Description                                                                                                                   |
+| ------------ | ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `results`    | `SearchResponse`  | The search result (a GeoJSON `FeatureCollection` with STAC links). `undefined` until the first successful response.           |
+| `isLoading`  | `boolean`         | `true` during the initial fetch (no cached data available). `false` once data is loaded or an error occurred.                 |
+| `isFetching` | `boolean`         | `true` during any in-flight request, including re-fetches triggered by payload changes. `false` otherwise.                    |
+| `error`      | [`Error`](#error) | Error information if the last request failed. `null` if the last request was successful.                                      |
+
+#### Example
+
+```jsx
+import { useState } from 'react';
+import { useStacQuery } from 'stac-react';
+
+function LiveSearch() {
+  const [collections, setCollections] = useState(['sentinel-2-l2a']);
+
+  // Automatically re-fetches whenever `collections` changes — no submit button needed.
+  const { results, isLoading, error } = useStacQuery({ collections });
+
+  if (isLoading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+
+  return (
+    <ul>
+      {results?.features.map(({ id }) => (
+        <li key={id}>{id}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
 ### Types
 
 #### Error

--- a/src/hooks/useStacQuery.test.ts
+++ b/src/hooks/useStacQuery.test.ts
@@ -1,0 +1,157 @@
+import fetch from 'jest-fetch-mock';
+import { renderHook, waitFor } from '@testing-library/react';
+import useStacQuery from './useStacQuery';
+import wrapper from './wrapper';
+
+const ROOT_POST = JSON.stringify({ links: [{ rel: 'search', method: 'POST' }] });
+const ROOT_GET = JSON.stringify({ links: [] });
+
+const makeFeatureCollection = (ids: string[]) =>
+  JSON.stringify({
+    type: 'FeatureCollection',
+    features: ids.map((id) => ({ id })),
+    links: [],
+  });
+
+describe('useStacQuery — API supports POST', () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+
+  it('automatically fetches results on mount', async () => {
+    fetch
+      .mockResponseOnce(ROOT_POST, { url: 'https://fake-stac-api.net' })
+      .mockResponseOnce(makeFeatureCollection(['item-1', 'item-2']));
+
+    const { result } = renderHook(() => useStacQuery({ collections: ['sentinel-2-l2a'] }), {
+      wrapper,
+    });
+
+    await waitFor(() =>
+      expect(result.current.results).toMatchObject({
+        type: 'FeatureCollection',
+        features: [{ id: 'item-1' }, { id: 'item-2' }],
+      })
+    );
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('sends correct POST payload with collections', async () => {
+    fetch
+      .mockResponseOnce(ROOT_POST, { url: 'https://fake-stac-api.net' })
+      .mockResponseOnce(makeFeatureCollection([]));
+
+    renderHook(() => useStacQuery({ collections: ['landsat-8-l1tp'] }), { wrapper });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    const body = JSON.parse(fetch.mock.calls[1][1]?.body as string);
+    expect(body).toMatchObject({ collections: ['landsat-8-l1tp'] });
+  });
+
+  it('sends correct POST payload with bbox', async () => {
+    fetch
+      .mockResponseOnce(ROOT_POST, { url: 'https://fake-stac-api.net' })
+      .mockResponseOnce(makeFeatureCollection([]));
+
+    renderHook(() => useStacQuery({ bbox: [-0.59, 51.24, 0.3, 51.74] }), { wrapper });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    const body = JSON.parse(fetch.mock.calls[1][1]?.body as string);
+    expect(body).toMatchObject({ bbox: [-0.59, 51.24, 0.3, 51.74] });
+  });
+
+  it('sends correct POST payload with date range', async () => {
+    fetch
+      .mockResponseOnce(ROOT_POST, { url: 'https://fake-stac-api.net' })
+      .mockResponseOnce(makeFeatureCollection([]));
+
+    renderHook(() => useStacQuery({ dateRange: { from: '2023-01-01', to: '2023-12-31' } }), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    const body = JSON.parse(fetch.mock.calls[1][1]?.body as string);
+    expect(body).toMatchObject({
+      datetime: '2023-01-01T00:00:00Z/2023-12-31T23:59:59Z',
+    });
+  });
+
+  it('refetches when payload changes', async () => {
+    fetch
+      .mockResponseOnce(ROOT_POST, { url: 'https://fake-stac-api.net' })
+      .mockResponseOnce(makeFeatureCollection(['item-a']))
+      .mockResponseOnce(makeFeatureCollection(['item-b']));
+
+    const { result, rerender } = renderHook((payload) => useStacQuery(payload), {
+      wrapper,
+      initialProps: { collections: ['collection-a'] },
+    });
+
+    await waitFor(() => expect(result.current.results?.features[0]?.id).toBe('item-a'));
+
+    rerender({ collections: ['collection-b'] });
+
+    await waitFor(() => expect(result.current.results?.features[0]?.id).toBe('item-b'));
+  });
+
+  it('handles error with JSON response', async () => {
+    fetch
+      .mockResponseOnce(ROOT_POST, { url: 'https://fake-stac-api.net' })
+      .mockResponseOnce(JSON.stringify({ error: 'Invalid query' }), {
+        status: 400,
+        statusText: 'Bad Request',
+      });
+
+    const { result } = renderHook(() => useStacQuery({ collections: ['sentinel-2-l2a'] }), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error).toMatchObject({
+      status: 400,
+      message: 'Bad Request',
+      detail: { error: 'Invalid query' },
+    });
+  });
+
+  it('handles error with non-JSON response', async () => {
+    fetch
+      .mockResponseOnce(ROOT_POST, { url: 'https://fake-stac-api.net' })
+      .mockResponseOnce('Internal Server Error', {
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+    const { result } = renderHook(() => useStacQuery({ collections: ['sentinel-2-l2a'] }), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error).toMatchObject({
+      status: 500,
+      message: 'Internal Server Error',
+      detail: 'Internal Server Error',
+    });
+  });
+});
+
+describe('useStacQuery — API supports GET', () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+
+  it('automatically fetches results using GET', async () => {
+    fetch
+      .mockResponseOnce(ROOT_GET, { url: 'https://fake-stac-api.net' })
+      .mockResponseOnce(makeFeatureCollection(['item-1']));
+
+    const { result } = renderHook(() => useStacQuery({ collections: ['sentinel-2-l2a'] }), {
+      wrapper,
+    });
+
+    await waitFor(() =>
+      expect(result.current.results).toMatchObject({ type: 'FeatureCollection' })
+    );
+    expect(fetch.mock.calls[1][0]).toMatch(/https:\/\/fake-stac-api\.net\/search/);
+  });
+});

--- a/src/hooks/useStacQuery.ts
+++ b/src/hooks/useStacQuery.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useStacApiContext } from '../context/useStacApiContext';
+import type { StacHook } from '../types';
+import type { SearchPayload, SearchResponse } from '../types/stac';
+import { handleStacResponse } from '../utils/handleStacResponse';
+import { ApiError } from '../utils/ApiError';
+
+interface StacQueryHook extends StacHook {
+  results?: SearchResponse | undefined;
+}
+
+/**
+ * Declarative STAC search hook that executes a search query whenever the
+ * parameters change. Unlike `useStacSearch`, there is no imperative `submit()`
+ * call — the query runs automatically when `stacApi` is available.
+ *
+ * @param payload - Search parameters (collections, dateRange, bbox, ids, sortby)
+ * @returns `{ results, isLoading, isFetching, error }`
+ */
+function useStacQuery(payload: SearchPayload): StacQueryHook {
+  const { stacApi } = useStacApiContext();
+
+  const queryFn = async () => {
+    if (!stacApi) throw new Error('No STAC API configured');
+    const response = await stacApi.search(payload);
+    return handleStacResponse<SearchResponse>(response);
+  };
+
+  const {
+    data: results,
+    error,
+    isLoading,
+    isFetching,
+  } = useQuery<SearchResponse, ApiError>({
+    queryKey: ['stacSearch', 'query', payload],
+    queryFn,
+    enabled: !!stacApi,
+    retry: false,
+  });
+
+  return {
+    results,
+    isLoading,
+    isFetching,
+    error,
+  };
+}
+
+// biome-ignore lint/style/noDefaultExport: This hook is intended to be the default export
+export default useStacQuery;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import useStacSearch from './hooks/useStacSearch';
+import useStacQuery from './hooks/useStacQuery';
 import useCollections from './hooks/useCollections';
 import useCollection from './hooks/useCollection';
 import useItem from './hooks/useItem';
@@ -6,4 +7,12 @@ import useStacApi from './hooks/useStacApi';
 import { StacApiProvider } from './context';
 
 export * from './types/stac.d';
-export { useCollections, useCollection, useItem, useStacSearch, useStacApi, StacApiProvider };
+export {
+  useCollections,
+  useCollection,
+  useItem,
+  useStacSearch,
+  useStacQuery,
+  useStacApi,
+  StacApiProvider,
+};


### PR DESCRIPTION
Adds `useStacQuery`, a declarative STAC search hook as a complement to the existing `useStacSearch`.

### Motivation

`useStacSearch` is designed for **imperative** UIs where the user explicitly presses a "Search" button. Many use cases benefit from a **declarative** model — results update automatically as filter state changes (e.g., collection picker, URL-driven search, map-extent search). `useStacQuery` fills that gap.

### Usage

```tsx
const { results, isLoading, error } = useStacQuery({
  collections: ['sentinel-2-l2a'],
  bbox: [-0.59, 51.24, 0.3, 51.74],
});
```
-------------
✨ AI-assisted change!