### PR TITLE
chore: cleanup StacApiContext type

### DIFF
--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -1,8 +1,8 @@
 import { createContext } from 'react';
+import type StacApi from '../stac-api';
 
 export type StacApiContextType = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  stacApi?: any;
+  stacApi?: StacApi;
 };
 
-export const StacApiContext = createContext<StacApiContextType>({} as StacApiContextType);
+export const StacApiContext = createContext<StacApiContextType>({});


### PR DESCRIPTION
In this PR, we enable stricter typing by utilizing the `StacApi` type rather than `any` for the `StacApiContext` value.