### PR TITLE
feat(auth): add getAuthHeaders callback for runtime token rotation

### DIFF
--- a/src/context/StacApiProvider.test.tsx
+++ b/src/context/StacApiProvider.test.tsx
@@ -143,6 +143,58 @@ describe('StacApiProvider', () => {
     });
   });
 
+  describe('getAuthHeaders integration', () => {
+    it('reads fresh auth headers across renders without rebuilding StacApi', async () => {
+      // Stateful getter simulates a login event after the provider mounts.
+      let token: string | undefined;
+      const getAuthHeaders = jest.fn(() =>
+        token ? { Authorization: `Bearer ${token}` } : undefined,
+      );
+
+      // Capture the StacApi instance to verify it's the *same* before/after login.
+      const seenInstances: unknown[] = [];
+
+      function Probe() {
+        const { stacApi } = useStacApiContext();
+        if (stacApi) seenInstances.push(stacApi);
+        return <div data-testid="ready">{stacApi ? 'ready' : 'loading'}</div>;
+      }
+
+      const { rerender } = render(
+        <StacApiProvider apiUrl="https://test-stac-api.com" getAuthHeaders={getAuthHeaders}>
+          <Probe />
+        </StacApiProvider>,
+      );
+
+      await waitFor(() => expect(screen.getByTestId('ready')).toHaveTextContent('ready'));
+
+      const stacApi = seenInstances[0] as { fetch: (url: string) => Promise<Response> };
+
+      // Pre-login: getter returns undefined, no Authorization injected.
+      (global.fetch as jest.Mock).mockClear();
+      await stacApi.fetch('https://test-stac-api.com/collections');
+      const preInit = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+      expect(preInit.headers).not.toHaveProperty('Authorization');
+
+      // Simulate login + a re-render (consumer would update its token state).
+      token = 'after-login';
+      rerender(
+        <StacApiProvider apiUrl="https://test-stac-api.com" getAuthHeaders={getAuthHeaders}>
+          <Probe />
+        </StacApiProvider>,
+      );
+
+      // Post-login: same StacApi instance, but next fetch carries the bearer.
+      (global.fetch as jest.Mock).mockClear();
+      await stacApi.fetch('https://test-stac-api.com/collections');
+      const postInit = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+      expect(postInit.headers).toMatchObject({ Authorization: 'Bearer after-login' });
+
+      // Same instance throughout — no rebuild on getter / token change.
+      expect(new Set(seenInstances).size).toBe(1);
+    });
+  });
+
   describe('Context value', () => {
     it('provides stacApi with correct apiUrl', async () => {
       function ApiUrlChecker() {

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -4,11 +4,21 @@ import { GenericObject } from '../types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import useStacApi from '../hooks/useStacApi';
+import type { AuthHeadersGetter } from '../stac-api';
 
 type StacApiProviderType = {
   apiUrl: string;
   children: React.ReactNode;
   options?: GenericObject;
+  /**
+   * Optional callback invoked per-request to retrieve auth headers (e.g.
+   * `{ Authorization: 'Bearer ...' }`). When provided, headers are merged
+   * into in-domain requests only — the bearer is never sent to URLs
+   * outside `apiUrl`'s origin / path. The callback identity may change
+   * across renders without rebuilding the underlying StacApi instance.
+   * See {@link AuthHeadersGetter} for an OIDC-refresh example.
+   */
+  getAuthHeaders?: AuthHeadersGetter;
   queryClient?: QueryClient;
   enableDevTools?: boolean;
 };
@@ -22,8 +32,9 @@ function StacApiProviderInner({
   children,
   apiUrl,
   options,
+  getAuthHeaders,
 }: Omit<StacApiProviderType, 'queryClient'>) {
-  const { stacApi } = useStacApi(apiUrl, options);
+  const { stacApi } = useStacApi(apiUrl, options, getAuthHeaders);
 
   const contextValue = useMemo(
     () => ({
@@ -39,6 +50,7 @@ export function StacApiProvider({
   children,
   apiUrl,
   options,
+  getAuthHeaders,
   queryClient,
   enableDevTools,
 }: StacApiProviderType) {
@@ -52,7 +64,7 @@ export function StacApiProvider({
 
   return (
     <QueryClientProvider client={client}>
-      <StacApiProviderInner apiUrl={apiUrl} options={options}>
+      <StacApiProviderInner apiUrl={apiUrl} options={options} getAuthHeaders={getAuthHeaders}>
         {children}
       </StacApiProviderInner>
     </QueryClientProvider>

--- a/src/hooks/useStacApi.ts
+++ b/src/hooks/useStacApi.ts
@@ -1,5 +1,6 @@
+import { useEffect, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import StacApi, { SearchMode } from '../stac-api';
+import StacApi, { AuthHeadersGetter, SearchMode } from '../stac-api';
 import { Link } from '../types/stac';
 import { GenericObject } from '../types';
 import { generateStacApiQueryKey } from '../utils/queryKeys';
@@ -11,8 +12,24 @@ type StacApiHook = {
   isError: boolean;
 };
 
-function useStacApi(url: string, options?: GenericObject): StacApiHook {
+function useStacApi(
+  url: string,
+  options?: GenericObject,
+  getAuthHeaders?: AuthHeadersGetter,
+): StacApiHook {
+  // Hold the latest getter in a ref so the StacApi instance can call back
+  // into a stable closure that always reads fresh values, without forcing
+  // a new query (and another landing-page probe) on each token change.
+  const getAuthHeadersRef = useRef<AuthHeadersGetter | undefined>(getAuthHeaders);
+  useEffect(() => {
+    getAuthHeadersRef.current = getAuthHeaders;
+  }, [getAuthHeaders]);
+
   const { data, isSuccess, isLoading, isError } = useQuery({
+    // getAuthHeaders is intentionally NOT part of the key — its identity
+    // changes across renders and we don't want to rebuild StacApi (which
+    // would re-fire the landing-page probe). Strict-Mode double-mounts
+    // are safe because staleTime: Infinity keeps the cached instance.
     queryKey: generateStacApiQueryKey(url, options),
     queryFn: async () => {
       const response = await fetch(url, {
@@ -26,7 +43,12 @@ function useStacApi(url: string, options?: GenericObject): StacApiHook {
         ({ rel, method }: Link) => rel === 'search' && method === 'POST'
       );
 
-      return new StacApi(response.url, doesPost ? SearchMode.POST : SearchMode.GET, options);
+      return new StacApi({
+        baseUrl: response.url,
+        searchMode: doesPost ? SearchMode.POST : SearchMode.GET,
+        options,
+        getAuthHeaders: () => getAuthHeadersRef.current?.(),
+      });
     },
     staleTime: Infinity,
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,16 @@ import useCollection from './hooks/useCollection';
 import useItem from './hooks/useItem';
 import useStacApi from './hooks/useStacApi';
 import { StacApiProvider } from './context';
+import { useStacApiContext } from './context/useStacApiContext';
 
 export * from './types/stac.d';
-export { useCollections, useCollection, useItem, useStacSearch, useStacApi, StacApiProvider };
+export type { AuthHeadersGetter } from './stac-api';
+export {
+  useCollections,
+  useCollection,
+  useItem,
+  useStacSearch,
+  useStacApi,
+  StacApiProvider,
+  useStacApiContext,
+};

--- a/src/stac-api/StacApi.test.ts
+++ b/src/stac-api/StacApi.test.ts
@@ -10,7 +10,10 @@ describe('StacApi', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    stacApi = new StacApi('https://api.example.com', SearchMode.POST);
+    stacApi = new StacApi({
+      baseUrl: 'https://api.example.com',
+      searchMode: SearchMode.POST,
+    });
   });
 
   describe('makeDatetimePayload', () => {
@@ -89,7 +92,10 @@ describe('StacApi', () => {
     });
 
     it('should transform dateRange to datetime string in GET mode', async () => {
-      const getStacApi = new StacApi('https://api.example.com', SearchMode.GET);
+      const getStacApi = new StacApi({
+        baseUrl: 'https://api.example.com',
+        searchMode: SearchMode.GET,
+      });
       const searchPayload: SearchRequestPayload = {
         collections: ['sentinel-2-l2a'],
         dateRange: { from: '2025-12-01', to: '2025-12-31' },
@@ -126,7 +132,10 @@ describe('StacApi', () => {
     });
 
     it('should not include undefined values in GET query string', async () => {
-      const getStacApi = new StacApi('https://api.example.com', SearchMode.GET);
+      const getStacApi = new StacApi({
+        baseUrl: 'https://api.example.com',
+        searchMode: SearchMode.GET,
+      });
       const searchPayload: SearchRequestPayload = {
         collections: ['sentinel-2-l2a'],
       };
@@ -140,6 +149,191 @@ describe('StacApi', () => {
           method: 'GET',
         })
       );
+    });
+  });
+
+  describe('auth headers getter', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({}),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+    });
+
+    function getSentHeaders(): Record<string, string> {
+      const init = mockFetch.mock.calls[0][1] as RequestInit;
+      return (init.headers || {}) as Record<string, string>;
+    }
+
+    function makeApi(
+      baseUrl: string,
+      getAuthHeaders?: () => Record<string, string> | undefined,
+      options?: { headers?: Record<string, string> },
+    ) {
+      return new StacApi({
+        baseUrl,
+        searchMode: SearchMode.GET,
+        options,
+        getAuthHeaders,
+      });
+    }
+
+    it('injects auth headers for in-domain requests', async () => {
+      const api = makeApi('https://api.example.com', () => ({ Authorization: 'Bearer tok-1' }));
+
+      await api.fetch('https://api.example.com/collections');
+
+      expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer tok-1' });
+    });
+
+    it('does not inject for out-of-domain URLs', async () => {
+      const api = makeApi('https://api.example.com', () => ({ Authorization: 'Bearer tok-1' }));
+
+      await api.fetch('https://other.example.com/asset.tif');
+
+      expect(getSentHeaders()).not.toHaveProperty('Authorization');
+    });
+
+    it('does not inject when getter returns undefined', async () => {
+      const api = makeApi('https://api.example.com', () => undefined);
+
+      await api.fetch('https://api.example.com/collections');
+
+      expect(getSentHeaders()).not.toHaveProperty('Authorization');
+    });
+
+    it('reads fresh headers on each call (no caching)', async () => {
+      let token = 'first';
+      const api = makeApi('https://api.example.com', () => ({ Authorization: `Bearer ${token}` }));
+
+      await api.fetch('https://api.example.com/collections');
+      expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer first' });
+
+      mockFetch.mockClear();
+      token = 'second';
+      await api.fetch('https://api.example.com/collections');
+      expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer second' });
+    });
+
+    it('login after construction: undefined → defined causes next fetch to carry headers', async () => {
+      let headers: Record<string, string> | undefined;
+      const api = makeApi('https://api.example.com', () => headers);
+
+      await api.fetch('https://api.example.com/collections');
+      expect(getSentHeaders()).not.toHaveProperty('Authorization');
+
+      mockFetch.mockClear();
+      headers = { Authorization: 'Bearer late', 'X-Tenant': 'acme' };
+      await api.fetch('https://api.example.com/collections');
+      expect(getSentHeaders()).toMatchObject({
+        Authorization: 'Bearer late',
+        'X-Tenant': 'acme',
+      });
+    });
+
+    it('lets call-time headers override the injected Authorization', async () => {
+      const api = makeApi('https://api.example.com', () => ({ Authorization: 'Bearer tok-1' }));
+
+      await api.fetch('https://api.example.com/collections', {
+        headers: { Authorization: 'Bearer override' },
+      });
+
+      expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer override' });
+    });
+
+    it('lets instance options.headers override the injected Authorization', async () => {
+      const api = makeApi(
+        'https://api.example.com',
+        () => ({ Authorization: 'Bearer tok-1' }),
+        { headers: { Authorization: 'Bearer static' } },
+      );
+
+      await api.fetch('https://api.example.com/collections');
+
+      expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer static' });
+    });
+
+    describe('isInDomain edge cases', () => {
+      const allow = () => ({ Authorization: 'Bearer t' });
+
+      it('rejects sibling host with shared prefix', async () => {
+        const api = makeApi('https://api.example.com', allow);
+        await api.fetch('https://api.example.com.evil.test/');
+        expect(getSentHeaders()).not.toHaveProperty('Authorization');
+      });
+
+      it('rejects userinfo confused-deputy', async () => {
+        const api = makeApi('https://api.example.com', allow);
+        await api.fetch('https://api.example.com@evil.test/foo');
+        expect(getSentHeaders()).not.toHaveProperty('Authorization');
+      });
+
+      it('treats default port (:443) as origin-equivalent', async () => {
+        const api = makeApi('https://api.example.com', allow);
+        await api.fetch('https://api.example.com:443/collections');
+        expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer t' });
+      });
+
+      it('treats uppercase host as origin-equivalent', async () => {
+        const api = makeApi('https://api.example.com', allow);
+        await api.fetch('https://API.EXAMPLE.COM/collections');
+        expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer t' });
+      });
+
+      it('injects on querystring-only path against bare baseUrl', async () => {
+        const api = makeApi('https://api.example.com', allow);
+        await api.fetch('https://api.example.com?x=1');
+        expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer t' });
+      });
+
+      it('injects on fragment-only against bare baseUrl', async () => {
+        const api = makeApi('https://api.example.com', allow);
+        await api.fetch('https://api.example.com#frag');
+        expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer t' });
+      });
+
+      it('path-scoped baseUrl: querystring at the root is in-domain', async () => {
+        const api = makeApi('https://api.example.com/v1', allow);
+        await api.fetch('https://api.example.com/v1?x=1');
+        expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer t' });
+      });
+
+      it('path-scoped baseUrl: deeper path is in-domain', async () => {
+        const api = makeApi('https://api.example.com/v1', allow);
+        await api.fetch('https://api.example.com/v1/collections/foo');
+        expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer t' });
+      });
+
+      it('path-scoped baseUrl: prefix-collision sibling path is rejected', async () => {
+        const api = makeApi('https://api.example.com/v1', allow);
+        await api.fetch('https://api.example.com/v10/collections');
+        expect(getSentHeaders()).not.toHaveProperty('Authorization');
+      });
+
+      it('rejects different origin (port mismatch)', async () => {
+        const api = makeApi('https://api.example.com', allow);
+        await api.fetch('https://api.example.com:8443/collections');
+        expect(getSentHeaders()).not.toHaveProperty('Authorization');
+      });
+
+      it('rejects http→https origin mismatch', async () => {
+        const api = makeApi('https://api.example.com', allow);
+        await api.fetch('http://api.example.com/collections');
+        expect(getSentHeaders()).not.toHaveProperty('Authorization');
+      });
+
+      it('rejects unparseable URL', async () => {
+        const api = makeApi('https://api.example.com', allow);
+        await api.fetch('not a url');
+        expect(getSentHeaders()).not.toHaveProperty('Authorization');
+      });
+
+      it('strips multiple trailing slashes from baseUrl', async () => {
+        const api = makeApi('https://api.example.com///', allow);
+        await api.fetch('https://api.example.com/collections');
+        expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer t' });
+      });
     });
   });
 

--- a/src/stac-api/index.ts
+++ b/src/stac-api/index.ts
@@ -8,6 +8,38 @@ type FetchOptions = {
   headers?: GenericObject;
 };
 
+/**
+ * Returns the auth headers to inject for the current request, or
+ * `undefined` when unauthenticated. Invoked per-request so callers can
+ * return fresh values without rebuilding the StacApi instance.
+ *
+ * Headers are only injected for in-domain requests (URLs whose origin and
+ * path are under {@link StacApi#baseUrl}) so secrets never leak to
+ * external resources such as presigned asset hrefs returned by STAC items.
+ *
+ * @example
+ * ```tsx
+ * const tokenRef = useRef<string | undefined>();
+ * useEffect(() => { tokenRef.current = oidc.user?.access_token; }, [oidc.user]);
+ *
+ * <StacApiProvider
+ *   apiUrl={url}
+ *   getAuthHeaders={() => {
+ *     const t = tokenRef.current;
+ *     return t ? { Authorization: `Bearer ${t}` } : undefined;
+ *   }}
+ * />
+ * ```
+ */
+export type AuthHeadersGetter = () => Record<string, string> | undefined;
+
+export type StacApiInit = {
+  baseUrl: string;
+  searchMode: SearchMode;
+  options?: GenericObject;
+  getAuthHeaders?: AuthHeadersGetter;
+};
+
 export enum SearchMode {
   GET = 'GET',
   POST = 'POST',
@@ -17,11 +49,48 @@ class StacApi {
   baseUrl: string;
   options?: GenericObject;
   searchMode = SearchMode.GET;
+  private getAuthHeaders?: AuthHeadersGetter;
 
-  constructor(baseUrl: string, searchMode: SearchMode, options?: GenericObject) {
-    this.baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
-    this.searchMode = searchMode;
-    this.options = options;
+  constructor(init: StacApiInit) {
+    this.baseUrl = init.baseUrl.replace(/\/+$/, '');
+    this.searchMode = init.searchMode;
+    this.options = init.options;
+    this.getAuthHeaders = init.getAuthHeaders;
+  }
+
+  /**
+   * True when `url` shares the same origin as `baseUrl` and its path is at
+   * or under `baseUrl.pathname`. Uses URL parsing (not string-prefix) so
+   * default ports, host casing, querystrings, and fragments don't produce
+   * false negatives, and prefix-collision hosts (`api.example.com.evil`)
+   * don't produce false positives. Returns false on parse failure.
+   */
+  private isInDomain(url: string): boolean {
+    let target: URL;
+    let base: URL;
+    try {
+      target = new URL(url);
+      base = new URL(this.baseUrl);
+    } catch {
+      return false;
+    }
+    if (target.origin !== base.origin) return false;
+    const basePath = base.pathname.endsWith('/') ? base.pathname : `${base.pathname}/`;
+    const targetPath = target.pathname.endsWith('/')
+      ? target.pathname
+      : `${target.pathname}/`;
+    return targetPath === basePath || targetPath.startsWith(basePath);
+  }
+
+  /**
+   * Resolve the auth headers to merge into a request. Empty unless a
+   * getter is configured, the URL is in-domain, and the getter returns
+   * a non-empty record.
+   */
+  private buildAuthHeaders(url: string): Record<string, string> {
+    if (!this.getAuthHeaders) return {};
+    if (!this.isInDomain(url)) return {};
+    return this.getAuthHeaders() ?? {};
   }
 
   fixBboxCoordinateOrder(bbox?: Bbox): Bbox | undefined {
@@ -87,12 +156,32 @@ class StacApi {
     return new URLSearchParams(queryObj).toString();
   }
 
+  /**
+   * Issue a request through the configured fetch implementation.
+   *
+   * Header precedence (last wins): auto-injected auth (from
+   * {@link AuthHeadersGetter}, in-domain only) → instance `options.headers`
+   * → per-call `headers`. Callers can suppress the injected header by
+   * passing `Authorization: ''` (or any explicit value), but cannot
+   * escalate to a token they don't already have.
+   *
+   * Redirect note: this method does not override `redirect`, so the global
+   * `fetch` default (`'follow'`) applies. Browsers strip `Authorization`
+   * on cross-origin redirects, but non-browser fetch implementations may
+   * not. If your STAC backend can 30x to a third-party host, configure
+   * the backend to avoid that or pass `redirect: 'manual'` via
+   * `options.headers` host-side configuration; the library does not
+   * re-check `isInDomain` after a redirect.
+   */
   async fetch(url: string, options: Partial<FetchOptions> = {}): Promise<Response> {
     const { method = 'GET', payload, headers = {} } = options;
 
     return fetch(url, {
       method,
       headers: {
+        // Auto-injected auth is a default that instance and call-time
+        // headers can override (suppress only — never escalate).
+        ...this.buildAuthHeaders(url),
         ...this.options?.headers,
         ...headers,
       },


### PR DESCRIPTION
StacApi accepts a getAuthHeaders() callback invoked per-request, so consumers can rotate auth (e.g. OIDC refresh) without rebuilding the StacApi instance and re-firing the landing-page probe. Headers are injected only for in-domain URLs (URL-parser based — origin + path prefix), so bearers never leak to external asset hrefs.

- StacApi: options-bag constructor, AuthHeadersGetter type, private buildAuthHeaders/isInDomain helpers
- useStacApi: ref-syncs the getter so identity changes don't rebuild the client
- StacApiProvider: forwards getAuthHeaders prop
- 13 origin/path edge-case tests + login-after-mount integration test