### PR TITLE
refactor!: use stac-ts for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "peerDependencies": {
     "@tanstack/react-query": ">=4.0.0",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "stac-ts": "^1"
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.90.5",
@@ -42,6 +43,7 @@
     "prettier": "^3.6.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "stac-ts": "^1.0.5",
     "ts-jest": "^29.4.5",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.2",

--- a/src/hooks/useCollection.ts
+++ b/src/hooks/useCollection.ts
@@ -1,23 +1,23 @@
 import { useQuery } from '@tanstack/react-query';
 import type { StacHook, StacRefetchFn } from '../types';
-import type { Collection } from '../types/stac';
+import type { StacCollection } from '../types/stac';
 import { handleStacResponse } from '../utils/handleStacResponse';
 import { generateCollectionQueryKey } from '../utils/queryKeys';
 import { useStacApiContext } from '../context/useStacApiContext';
 import { ApiError } from '../utils/ApiError';
 
 interface StacCollectionHook extends StacHook {
-  collection?: Collection;
-  refetch: StacRefetchFn<Collection>;
+  collection?: StacCollection;
+  refetch: StacRefetchFn<StacCollection>;
 }
 
 function useCollection(collectionId: string): StacCollectionHook {
   const { stacApi } = useStacApiContext();
 
-  const fetchCollection = async (): Promise<Collection> => {
+  const fetchCollection = async (): Promise<StacCollection> => {
     if (!stacApi) throw new Error('No STAC API configured');
     const response: Response = await stacApi.getCollection(collectionId);
-    return handleStacResponse<Collection>(response);
+    return handleStacResponse<StacCollection>(response);
   };
 
   const {
@@ -26,7 +26,7 @@ function useCollection(collectionId: string): StacCollectionHook {
     isLoading,
     isFetching,
     refetch,
-  } = useQuery<Collection, ApiError>({
+  } = useQuery<StacCollection, ApiError>({
     queryKey: generateCollectionQueryKey(collectionId),
     queryFn: fetchCollection,
     enabled: !!stacApi,

--- a/src/hooks/useItem.ts
+++ b/src/hooks/useItem.ts
@@ -1,23 +1,23 @@
 import { useQuery } from '@tanstack/react-query';
 import type { StacHook, StacRefetchFn } from '../types';
-import type { Item } from '../types/stac';
+import type { StacItem } from '../types/stac';
 import { useStacApiContext } from '../context/useStacApiContext';
 import { handleStacResponse } from '../utils/handleStacResponse';
 import { generateItemQueryKey } from '../utils/queryKeys';
 import { ApiError } from '../utils/ApiError';
 
 interface StacItemHook extends StacHook {
-  item?: Item;
-  refetch: StacRefetchFn<Item>;
+  item?: StacItem;
+  refetch: StacRefetchFn<StacItem>;
 }
 
 function useItem(url: string): StacItemHook {
   const { stacApi } = useStacApiContext();
 
-  const fetchItem = async (): Promise<Item> => {
+  const fetchItem = async (): Promise<StacItem> => {
     if (!stacApi) throw new Error('No STAC API configured');
     const response: Response = await stacApi.get(url);
-    return handleStacResponse<Item>(response);
+    return handleStacResponse<StacItem>(response);
   };
 
   const {
@@ -26,7 +26,7 @@ function useItem(url: string): StacItemHook {
     isLoading,
     isFetching,
     refetch,
-  } = useQuery<Item, ApiError>({
+  } = useQuery<StacItem, ApiError>({
     queryKey: generateItemQueryKey(url),
     queryFn: fetchItem,
     enabled: !!stacApi,

--- a/src/types/stac.d.ts
+++ b/src/types/stac.d.ts
@@ -116,17 +116,34 @@ export type Extent = {
 };
 
 export type Collection = {
+  // Must be set to `Collection` to be a valid Collection.
   type: 'Collection';
+  // The STAC version the Collection implements.
   stac_version: string;
+  // A list of extension identifiers the Collection implements.
   stac_extensions?: string[];
+  // Identifier for the Collection that is unique across all collections in the root catalog.
   id: string;
+  // short descriptive one-line title for the Collection.
   title?: string;
+  // Detailed multi-line description to fully explain the Collection. CommonMark 0.29 syntax MAY be used for rich text representation.
+  description: string;
+  // List of keywords describing the Collection.
   keywords?: string[];
+  // License(s) of the data collection as SPDX License identifier, SPDX License expression, or `other`.
   license: string;
-  providers: Provider[];
+  // A list of providers, which may include all organizations capturing or processing the data or the hosting provider.
+  providers?: Provider[];
+  // Spatial and temporal extents.
   extent: Extent;
+  // STRONGLY RECOMMENDED. A map of property summaries, either a set of values, a range of values or a JSON Schema.
+  summaries?: Record<string, unknown>;
+  // A list of references to other documents.
   links: Link[];
-  assets: Record<string, ItemAsset>;
+  // Dictionary of asset objects that can be downloaded, each with a unique key.
+  assets?: Record<string, ItemAsset>;
+  // A dictionary of assets that can be found in member Items.
+  item_assets?: Record<string, Omit<ItemAsset, 'href'>>;
 };
 
 export type CollectionsResponse = {

--- a/src/types/stac.d.ts
+++ b/src/types/stac.d.ts
@@ -1,13 +1,33 @@
-import type { Geometry } from 'geojson';
 import type { GenericObject } from '.';
+import type { StacItem, StacLink, StacCollection } from 'stac-ts';
+
+// Re-export stac-ts types so consumers can rely on stac-react as a single
+// import surface for STAC documents.
+export type {
+  StacAsset,
+  StacCatalog,
+  StacCollection,
+  StacExtensions,
+  StacItem,
+  StacLink,
+  StacProvider,
+  StacRoles,
+  StacVersion,
+} from 'stac-ts';
+
+// ---------------------------------------------------------------------------
+// stac-react-specific search input types
+// ---------------------------------------------------------------------------
 
 export type Bbox = [number, number, number, number];
 export type IdList = string[];
 export type CollectionIdList = string[];
+
 export type DateRange = {
   from?: string;
   to?: string;
 };
+
 export type Sortby = {
   field: string;
   direction: 'asc' | 'desc';
@@ -52,22 +72,25 @@ export type FetchRequest =
       url: string;
     };
 
+/**
+ * Body shape for STAC pagination links. Links served as `rel: next` may
+ * carry a structured `body` describing the next-page POST payload; this
+ * extends SearchPayload with a `merge` flag so the consumer knows whether
+ * to merge with the current search params.
+ */
 export type LinkBody = SearchPayload & {
   merge?: boolean;
 };
 
-export type SearchResponse = {
-  type: 'FeatureCollection';
-  features: Item[];
-  links: Link[];
-};
-
-export type Link = {
-  href: string;
-  rel: string;
-  type?: string;
+/**
+ * Pagination-aware extension of StacLink. STAC servers MAY add a typed
+ * `body` (per OGC API STAC pagination), plus stac-react surfaces `method`,
+ * `headers`, and `merge` for the consumer hooks. The base StacLink index
+ * signature already permits these fields; this type just gives them
+ * static types where stac-react reads them.
+ */
+export type Link = StacLink & {
   hreflang?: string;
-  title?: string;
   length?: number;
   method?: string;
   headers?: GenericObject;
@@ -75,78 +98,17 @@ export type Link = {
   merge?: boolean;
 };
 
-export type ItemAsset = {
-  href: string;
-  title?: string;
-  description?: string;
-  type?: string;
-  roles?: string[];
-};
+// ---------------------------------------------------------------------------
+// stac-react response wrappers (around stac-ts documents)
+// ---------------------------------------------------------------------------
 
-export type Item = {
-  id: string;
-  bbox: Bbox;
-  geometry: Geometry;
-  type: 'Feature';
-  properties: GenericObject;
+export type SearchResponse = {
+  type: 'FeatureCollection';
+  features: StacItem[];
   links: Link[];
-  assets: Record<string, ItemAsset>;
-};
-
-type Role = 'licensor' | 'producer' | 'processor' | 'host';
-
-export type Provider = {
-  name: string;
-  description?: string;
-  roles?: Role[];
-  url: string;
-};
-
-type SpatialExtent = {
-  bbox: number[][];
-};
-
-type TemporalExtent = {
-  interval: string | null[][];
-};
-
-export type Extent = {
-  spatial: SpatialExtent;
-  temporal: TemporalExtent;
-};
-
-export type Collection = {
-  // Must be set to `Collection` to be a valid Collection.
-  type: 'Collection';
-  // The STAC version the Collection implements.
-  stac_version: string;
-  // A list of extension identifiers the Collection implements.
-  stac_extensions?: string[];
-  // Identifier for the Collection that is unique across all collections in the root catalog.
-  id: string;
-  // short descriptive one-line title for the Collection.
-  title?: string;
-  // Detailed multi-line description to fully explain the Collection. CommonMark 0.29 syntax MAY be used for rich text representation.
-  description: string;
-  // List of keywords describing the Collection.
-  keywords?: string[];
-  // License(s) of the data collection as SPDX License identifier, SPDX License expression, or `other`.
-  license: string;
-  // A list of providers, which may include all organizations capturing or processing the data or the hosting provider.
-  providers?: Provider[];
-  // Spatial and temporal extents.
-  extent: Extent;
-  // STRONGLY RECOMMENDED. A map of property summaries, either a set of values, a range of values or a JSON Schema.
-  summaries?: Record<string, unknown>;
-  // A list of references to other documents.
-  links: Link[];
-  // Dictionary of asset objects that can be downloaded, each with a unique key.
-  assets?: Record<string, ItemAsset>;
-  // A dictionary of assets that can be found in member Items.
-  item_assets?: Record<string, Omit<ItemAsset, 'href'>>;
 };
 
 export type CollectionsResponse = {
-  collections: Collection[];
+  collections: StacCollection[];
   links: Link[];
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -558,6 +558,7 @@ __metadata:
     prettier: "npm:^3.6.2"
     react: "npm:^19.2.0"
     react-dom: "npm:^19.2.0"
+    stac-ts: "npm:^1.0.5"
     ts-jest: "npm:^29.4.5"
     typescript: "npm:~5.9.3"
     typescript-eslint: "npm:^8.46.2"
@@ -567,6 +568,7 @@ __metadata:
     "@tanstack/react-query": ">=4.0.0"
     react: ^19.2.0
     react-dom: ^19.2.0
+    stac-ts: ^1
   languageName: unknown
   linkType: soft
 
@@ -7079,6 +7081,13 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/caddd5f544b2006e88fa6b0124d8d7b28208b83c72d7672d5ade44d794525d23b540f3396108c4eb9280dcb7c01f0bef50682f5b4b2c34291f7c5e211fd1417d
+  languageName: node
+  linkType: hard
+
+"stac-ts@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "stac-ts@npm:1.0.5"
+  checksum: 10c0/dd406f4b52ea9d5114a81d98fc60a3100cdf20f681572f2950caa2aed3465dba8105cac737dd4c7b484907199baed4f62b0c4ffae3015fd94f5091371ba2ad06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
While the `stac-manager` uses `stac-ts` for types[^1], this project creates its own types for STAC objects. This puts a maintenance burden on the project (e.g. I initially started down this path of exploration when I realized that our `Collection` type was missing the required `description` field.)

This PR add `stac-ts` as a `peerDependency` of the project.

[^1]: https://github.com/developmentseed/stac-manager/blob/c63c760829f018722198dfeecd2ba925fb4ba664/packages/client/package.json#L89