### PR TITLE
feat(stac-api): accept callable options resolved at call time

### DIFF
--- a/src/context/StacApiProvider.test.tsx
+++ b/src/context/StacApiProvider.test.tsx
@@ -143,6 +143,58 @@ describe('StacApiProvider', () => {
     });
   });
 
+  describe('callable options integration', () => {
+    it('reads fresh options across renders without rebuilding StacApi', async () => {
+      // Stateful options simulates a login event after the provider mounts.
+      let token: string | undefined;
+      const options = jest.fn(() =>
+        token ? { headers: { Authorization: `Bearer ${token}` } } : undefined,
+      );
+
+      // Capture the StacApi instance to verify it's the *same* before/after login.
+      const seenInstances: unknown[] = [];
+
+      function Probe() {
+        const { stacApi } = useStacApiContext();
+        if (stacApi) seenInstances.push(stacApi);
+        return <div data-testid="ready">{stacApi ? 'ready' : 'loading'}</div>;
+      }
+
+      const { rerender } = render(
+        <StacApiProvider apiUrl="https://test-stac-api.com" options={options}>
+          <Probe />
+        </StacApiProvider>,
+      );
+
+      await waitFor(() => expect(screen.getByTestId('ready')).toHaveTextContent('ready'));
+
+      const stacApi = seenInstances[0] as { fetch: (url: string) => Promise<Response> };
+
+      // Pre-login: options returns undefined, no Authorization sent.
+      (global.fetch as jest.Mock).mockClear();
+      await stacApi.fetch('https://test-stac-api.com/collections');
+      const preInit = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+      expect(preInit.headers).not.toHaveProperty('Authorization');
+
+      // Simulate login + a re-render (consumer would update its token state).
+      token = 'after-login';
+      rerender(
+        <StacApiProvider apiUrl="https://test-stac-api.com" options={options}>
+          <Probe />
+        </StacApiProvider>,
+      );
+
+      // Post-login: same StacApi instance, but next fetch carries the bearer.
+      (global.fetch as jest.Mock).mockClear();
+      await stacApi.fetch('https://test-stac-api.com/collections');
+      const postInit = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+      expect(postInit.headers).toMatchObject({ Authorization: 'Bearer after-login' });
+
+      // Same instance throughout — no rebuild on options / token change.
+      expect(new Set(seenInstances).size).toBe(1);
+    });
+  });
+
   describe('Context value', () => {
     it('provides stacApi with correct apiUrl', async () => {
       function ApiUrlChecker() {

--- a/src/context/StacApiProvider.test.tsx
+++ b/src/context/StacApiProvider.test.tsx
@@ -146,9 +146,9 @@ describe('StacApiProvider', () => {
   describe('callable options integration', () => {
     it('reads fresh options across renders without rebuilding StacApi', async () => {
       // Stateful options simulates a login event after the provider mounts.
-      let token: string | undefined;
+      let token: string | undefined = undefined;
       const options = jest.fn(() =>
-        token ? { headers: { Authorization: `Bearer ${token}` } } : undefined,
+        token ? { headers: { Authorization: `Bearer ${token}` } } : undefined
       );
 
       // Capture the StacApi instance to verify it's the *same* before/after login.
@@ -163,7 +163,7 @@ describe('StacApiProvider', () => {
       const { rerender } = render(
         <StacApiProvider apiUrl="https://test-stac-api.com" options={options}>
           <Probe />
-        </StacApiProvider>,
+        </StacApiProvider>
       );
 
       await waitFor(() => expect(screen.getByTestId('ready')).toHaveTextContent('ready'));
@@ -181,7 +181,7 @@ describe('StacApiProvider', () => {
       rerender(
         <StacApiProvider apiUrl="https://test-stac-api.com" options={options}>
           <Probe />
-        </StacApiProvider>,
+        </StacApiProvider>
       );
 
       // Post-login: same StacApi instance, but next fetch carries the bearer.

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -4,11 +4,18 @@ import { GenericObject } from '../types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import useStacApi from '../hooks/useStacApi';
+import type { OptionsGetter } from '../stac-api';
 
 type StacApiProviderType = {
   apiUrl: string;
   children: React.ReactNode;
-  options?: GenericObject;
+  /**
+   * Static options applied to every request, or a function invoked
+   * per-request that returns options. Use the function form when values
+   * (e.g. an auth header) must update across renders without rebuilding
+   * the underlying StacApi instance. See {@link OptionsGetter}.
+   */
+  options?: GenericObject | OptionsGetter;
   queryClient?: QueryClient;
   enableDevTools?: boolean;
 };

--- a/src/hooks/useStacApi.ts
+++ b/src/hooks/useStacApi.ts
@@ -1,5 +1,6 @@
+import { useEffect, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import StacApi, { SearchMode } from '../stac-api';
+import StacApi, { OptionsGetter, SearchMode } from '../stac-api';
 import { Link } from '../types/stac';
 import { GenericObject } from '../types';
 import { generateStacApiQueryKey } from '../utils/queryKeys';
@@ -11,13 +12,35 @@ type StacApiHook = {
   isError: boolean;
 };
 
-function useStacApi(url: string, options?: GenericObject): StacApiHook {
+function resolveOptions(
+  options: GenericObject | OptionsGetter | undefined,
+): GenericObject | undefined {
+  return typeof options === 'function' ? options() : options;
+}
+
+function useStacApi(
+  url: string,
+  options?: GenericObject | OptionsGetter,
+): StacApiHook {
+  // Hold the latest options in a ref so the StacApi instance reads fresh
+  // values per request without rebuilding (which would re-fire the
+  // landing-page probe). Both static and callable forms route through
+  // the ref, so consumers don't have to memoize a static options object.
+  const optionsRef = useRef(options);
+  useEffect(() => {
+    optionsRef.current = options;
+  }, [options]);
+
   const { data, isSuccess, isLoading, isError } = useQuery({
-    queryKey: generateStacApiQueryKey(url, options),
+    // options is intentionally NOT part of the key — see optionsRef above.
+    // Strict-Mode double-mounts are safe because staleTime: Infinity keeps
+    // the cached instance.
+    queryKey: generateStacApiQueryKey(url),
     queryFn: async () => {
+      const initial = resolveOptions(optionsRef.current);
       const response = await fetch(url, {
         headers: {
-          ...options?.headers,
+          ...initial?.headers,
         },
       });
       const stacData = await handleStacResponse<{ links?: Link[] }>(response);
@@ -26,7 +49,11 @@ function useStacApi(url: string, options?: GenericObject): StacApiHook {
         ({ rel, method }: Link) => rel === 'search' && method === 'POST'
       );
 
-      return new StacApi(response.url, doesPost ? SearchMode.POST : SearchMode.GET, options);
+      return new StacApi(
+        response.url,
+        doesPost ? SearchMode.POST : SearchMode.GET,
+        () => resolveOptions(optionsRef.current),
+      );
     },
     staleTime: Infinity,
   });

--- a/src/hooks/useStacApi.ts
+++ b/src/hooks/useStacApi.ts
@@ -13,18 +13,14 @@ type StacApiHook = {
 };
 
 function resolveOptions(
-  options: GenericObject | OptionsGetter | undefined,
+  options: GenericObject | OptionsGetter | undefined
 ): GenericObject | undefined {
   return typeof options === 'function' ? options() : options;
 }
 
-function useStacApi(
-  url: string,
-  options?: GenericObject | OptionsGetter,
-): StacApiHook {
-  // Hold the latest options in a ref so the StacApi instance reads fresh
-  // values per request without rebuilding (which would re-fire the
-  // landing-page probe). Both static and callable forms route through
+function useStacApi(url: string, options?: GenericObject | OptionsGetter): StacApiHook {
+  // Hold the latest options in a ref so the StacApi instance reads fresh values
+  // per request without rebuilding. Both static and callable forms route through
   // the ref, so consumers don't have to memoize a static options object.
   const optionsRef = useRef(options);
   useEffect(() => {
@@ -45,15 +41,13 @@ function useStacApi(
       });
       const stacData = await handleStacResponse<{ links?: Link[] }>(response);
 
-      const doesPost = stacData.links?.find(
+      const searchMode = stacData.links?.find(
         ({ rel, method }: Link) => rel === 'search' && method === 'POST'
-      );
+      )
+        ? SearchMode.POST
+        : SearchMode.GET;
 
-      return new StacApi(
-        response.url,
-        doesPost ? SearchMode.POST : SearchMode.GET,
-        () => resolveOptions(optionsRef.current),
-      );
+      return new StacApi(response.url, searchMode, () => resolveOptions(optionsRef.current));
     },
     staleTime: Infinity,
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,16 @@ import useCollection from './hooks/useCollection';
 import useItem from './hooks/useItem';
 import useStacApi from './hooks/useStacApi';
 import { StacApiProvider } from './context';
+import { useStacApiContext } from './context/useStacApiContext';
 
 export * from './types/stac.d';
-export { useCollections, useCollection, useItem, useStacSearch, useStacApi, StacApiProvider };
+export type { OptionsGetter } from './stac-api';
+export {
+  useCollections,
+  useCollection,
+  useItem,
+  useStacSearch,
+  useStacApi,
+  StacApiProvider,
+  useStacApiContext,
+};

--- a/src/stac-api/StacApi.test.ts
+++ b/src/stac-api/StacApi.test.ts
@@ -143,6 +143,97 @@ describe('StacApi', () => {
     });
   });
 
+  describe('options', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({}),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+    });
+
+    function getSentHeaders(): Record<string, string> {
+      const init = mockFetch.mock.calls[0][1] as RequestInit;
+      return (init.headers || {}) as Record<string, string>;
+    }
+
+    it('applies static options.headers to every request', async () => {
+      const api = new StacApi('https://api.example.com', SearchMode.GET, {
+        headers: { 'X-Static': 'on' },
+      });
+
+      await api.fetch('https://api.example.com/collections');
+      expect(getSentHeaders()).toMatchObject({ 'X-Static': 'on' });
+    });
+
+    it('resolves callable options at call time', async () => {
+      const api = new StacApi('https://api.example.com', SearchMode.GET, () => ({
+        headers: { Authorization: 'Bearer tok-1' },
+      }));
+
+      await api.fetch('https://api.example.com/collections');
+      expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer tok-1' });
+    });
+
+    it('reads fresh values from a callable on each request', async () => {
+      let token = 'first';
+      const api = new StacApi('https://api.example.com', SearchMode.GET, () => ({
+        headers: { Authorization: `Bearer ${token}` },
+      }));
+
+      await api.fetch('https://api.example.com/collections');
+      expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer first' });
+
+      mockFetch.mockClear();
+      token = 'second';
+      await api.fetch('https://api.example.com/collections');
+      expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer second' });
+    });
+
+    it('handles callable returning undefined (unauthenticated state)', async () => {
+      let opts: { headers: Record<string, string> } | undefined;
+      const api = new StacApi(
+        'https://api.example.com',
+        SearchMode.GET,
+        () => opts,
+      );
+
+      await api.fetch('https://api.example.com/collections');
+      expect(getSentHeaders()).not.toHaveProperty('Authorization');
+
+      mockFetch.mockClear();
+      opts = { headers: { Authorization: 'Bearer late' } };
+      await api.fetch('https://api.example.com/collections');
+      expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer late' });
+    });
+
+    it('lets call-time headers override options.headers', async () => {
+      const api = new StacApi('https://api.example.com', SearchMode.GET, () => ({
+        headers: { Authorization: 'Bearer tok-1' },
+      }));
+
+      await api.fetch('https://api.example.com/collections', {
+        headers: { Authorization: 'Bearer override' },
+      });
+      expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer override' });
+    });
+
+    it('sends options.headers on any URL the caller passes (no in-domain scoping)', async () => {
+      const api = new StacApi('https://api.example.com', SearchMode.GET, () => ({
+        headers: { Authorization: 'Bearer tok-1' },
+      }));
+
+      await api.fetch('https://other.example.com/asset.tif');
+      // Library does no scoping; consumers must gate sensitive URLs themselves.
+      expect(getSentHeaders()).toMatchObject({ Authorization: 'Bearer tok-1' });
+    });
+
+    it('strips multiple trailing slashes from baseUrl', () => {
+      const api = new StacApi('https://api.example.com///', SearchMode.GET);
+      expect(api.baseUrl).toBe('https://api.example.com');
+    });
+  });
+
   describe('payloadToQuery', () => {
     it('should convert arrays to comma-separated strings', () => {
       const payload = {

--- a/src/stac-api/StacApi.test.ts
+++ b/src/stac-api/StacApi.test.ts
@@ -157,10 +157,10 @@ describe('StacApi', () => {
       return (init.headers || {}) as Record<string, string>;
     }
 
-    it('applies static options.headers to every request', async () => {
-      const api = new StacApi('https://api.example.com', SearchMode.GET, {
+    it('applies options.headers to every request', async () => {
+      const api = new StacApi('https://api.example.com', SearchMode.GET, () => ({
         headers: { 'X-Static': 'on' },
-      });
+      }));
 
       await api.fetch('https://api.example.com/collections');
       expect(getSentHeaders()).toMatchObject({ 'X-Static': 'on' });

--- a/src/stac-api/StacApi.test.ts
+++ b/src/stac-api/StacApi.test.ts
@@ -191,12 +191,8 @@ describe('StacApi', () => {
     });
 
     it('handles callable returning undefined (unauthenticated state)', async () => {
-      let opts: { headers: Record<string, string> } | undefined;
-      const api = new StacApi(
-        'https://api.example.com',
-        SearchMode.GET,
-        () => opts,
-      );
+      let opts: { headers: Record<string, string> } | undefined = undefined;
+      const api = new StacApi('https://api.example.com', SearchMode.GET, () => opts);
 
       await api.fetch('https://api.example.com/collections');
       expect(getSentHeaders()).not.toHaveProperty('Authorization');

--- a/src/stac-api/index.ts
+++ b/src/stac-api/index.ts
@@ -8,6 +8,34 @@ type FetchOptions = {
   headers?: GenericObject;
 };
 
+/**
+ * Resolves request options at call time. Pass a function form of
+ * `options` when values must vary across renders (e.g. an auth header
+ * driven by a token that rotates) without rebuilding the StacApi
+ * instance.
+ *
+ * stac-react does no scoping of these options — they're sent on every
+ * request `StacApi.fetch` issues, including any URL the caller passes
+ * (item asset hrefs, etc.). If you need to keep secrets off external
+ * URLs, gate at the consumer (e.g. don't route external URLs through
+ * `stacApi.fetch`, or wrap it with your own URL check).
+ *
+ * @example
+ * ```tsx
+ * const tokenRef = useRef<string | undefined>();
+ * useEffect(() => { tokenRef.current = oidc.user?.access_token; }, [oidc.user]);
+ *
+ * <StacApiProvider
+ *   apiUrl={url}
+ *   options={() => {
+ *     const t = tokenRef.current;
+ *     return t ? { headers: { Authorization: `Bearer ${t}` } } : undefined;
+ *   }}
+ * />
+ * ```
+ */
+export type OptionsGetter = () => GenericObject | undefined;
+
 export enum SearchMode {
   GET = 'GET',
   POST = 'POST',
@@ -15,13 +43,21 @@ export enum SearchMode {
 
 class StacApi {
   baseUrl: string;
-  options?: GenericObject;
+  options?: GenericObject | OptionsGetter;
   searchMode = SearchMode.GET;
 
-  constructor(baseUrl: string, searchMode: SearchMode, options?: GenericObject) {
-    this.baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+  constructor(
+    baseUrl: string,
+    searchMode: SearchMode,
+    options?: GenericObject | OptionsGetter,
+  ) {
+    this.baseUrl = baseUrl.replace(/\/+$/, '');
     this.searchMode = searchMode;
     this.options = options;
+  }
+
+  private resolveOptions(): GenericObject | undefined {
+    return typeof this.options === 'function' ? this.options() : this.options;
   }
 
   fixBboxCoordinateOrder(bbox?: Bbox): Bbox | undefined {
@@ -87,13 +123,20 @@ class StacApi {
     return new URLSearchParams(queryObj).toString();
   }
 
+  /**
+   * Issue a request through the configured fetch implementation.
+   *
+   * Header precedence (last wins): instance `options.headers` (resolved
+   * at call time when `options` is a function) → per-call `headers`.
+   */
   async fetch(url: string, options: Partial<FetchOptions> = {}): Promise<Response> {
     const { method = 'GET', payload, headers = {} } = options;
+    const resolved = this.resolveOptions();
 
     return fetch(url, {
       method,
       headers: {
-        ...this.options?.headers,
+        ...resolved?.headers,
         ...headers,
       },
       body: payload ? JSON.stringify(payload) : undefined,

--- a/src/stac-api/index.ts
+++ b/src/stac-api/index.ts
@@ -1,10 +1,9 @@
 import type { GenericObject } from '../types';
 import type { Bbox, SearchPayload, DateRange } from '../types/stac';
 
-type RequestPayload = SearchPayload;
 type FetchOptions = {
   method?: string;
-  payload?: RequestPayload;
+  payload?: unknown;
   headers?: GenericObject;
 };
 
@@ -43,21 +42,13 @@ export enum SearchMode {
 
 class StacApi {
   baseUrl: string;
-  options?: GenericObject | OptionsGetter;
+  options?: OptionsGetter;
   searchMode = SearchMode.GET;
 
-  constructor(
-    baseUrl: string,
-    searchMode: SearchMode,
-    options?: GenericObject | OptionsGetter,
-  ) {
+  constructor(baseUrl: string, searchMode: SearchMode, options?: OptionsGetter) {
     this.baseUrl = baseUrl.replace(/\/+$/, '');
     this.searchMode = searchMode;
     this.options = options;
-  }
-
-  private resolveOptions(): GenericObject | undefined {
-    return typeof this.options === 'function' ? this.options() : this.options;
   }
 
   fixBboxCoordinateOrder(bbox?: Bbox): Bbox | undefined {
@@ -131,12 +122,11 @@ class StacApi {
    */
   async fetch(url: string, options: Partial<FetchOptions> = {}): Promise<Response> {
     const { method = 'GET', payload, headers = {} } = options;
-    const resolved = this.resolveOptions();
 
     return fetch(url, {
       method,
       headers: {
-        ...resolved?.headers,
+        ...this.options?.()?.headers,
         ...headers,
       },
       body: payload ? JSON.stringify(payload) : undefined,


### PR DESCRIPTION
## What I'm changing

The PR enables _dynamic_ options to accompany requests to a STAC API. My current use case is to pass in a callable `options` parameter that fetches the latest authorization header (https://github.com/developmentseed/stac-manager/pull/71), which allows us to maintain the same STAC API instance while the underlying auth token is refreshed within my application.

## How I did it

`StacApiProvider`/`useStacApi`/`StacApi` now accept `options` as either the existing static `GenericObject` (backward compatible) or a function of type `OptionsGetter` invoked per request. The function form lets consumers rotate values (auth headers, custom headers, signal, etc.) without rebuilding the StacApi instance and re-firing the landing-page probe.

Internally, `useStacApi` ref-stabilizes whatever options form was passed and excludes it from the react-query queryKey, so identity changes across renders no longer cause client rebuilds. Static options no longer need to be memoized.

> [!NOTE]
> It wasn't really clear to me why `options` were ever part of the `queryKey`. It's worth considering if they need to be there for any reason that I'm not seeing.

The constructor signature stays positional `(baseUrl, searchMode, options?)` — the only change to the existing API surface is widening the `options` type to `GenericObject | OptionsGetter`.