### PR TITLE
fix: prevent refetch of STAC API when options change

### DIFF
--- a/src/hooks/useStacApi.test.ts
+++ b/src/hooks/useStacApi.test.ts
@@ -1,6 +1,9 @@
+import React from 'react';
 import fetch from 'jest-fetch-mock';
 import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import useCollections from './useCollections';
+import useStacApi from './useStacApi';
 import wrapper from './wrapper';
 
 describe('useStacApi', () => {
@@ -30,5 +33,61 @@ describe('useStacApi', () => {
     await waitFor(() =>
       expect(fetch.mock.calls[1][0]).toEqual('https://fake-stac-api.net/redirect/collections')
     );
+  });
+
+  it('does not refetch when options change', async () => {
+    fetch.mockResponse(JSON.stringify({ links: [] }), { url: 'https://fake-stac-api.net' });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const customWrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const initialProps: { options: Record<string, unknown> } = {
+      options: { headers: { Authorization: 'Bearer token1' } },
+    };
+    const { rerender } = renderHook(
+      ({ options }: { options: Record<string, unknown> }) =>
+        useStacApi('https://fake-stac-api.net', options),
+      { wrapper: customWrapper, initialProps }
+    );
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+    // Re-render with a new options reference whose contents also differ.
+    rerender({ options: { headers: { Authorization: 'Bearer token2' } } });
+    // Re-render with a completely different options shape.
+    rerender({ options: { foo: 'bar' } });
+    // Re-render with a fresh reference but equivalent contents to the prior call.
+    rerender({ options: { foo: 'bar' } });
+
+    // Yield to allow any pending refetch to fire before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches when url changes', async () => {
+    fetch.mockResponse(JSON.stringify({ links: [] }));
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const customWrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { rerender } = renderHook(({ url }: { url: string }) => useStacApi(url), {
+      wrapper: customWrapper,
+      initialProps: { url: 'https://fake-stac-api.net/a' },
+    });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    expect(fetch.mock.calls[0][0]).toEqual('https://fake-stac-api.net/a');
+
+    rerender({ url: 'https://fake-stac-api.net/b' });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    expect(fetch.mock.calls[1][0]).toEqual('https://fake-stac-api.net/b');
   });
 });

--- a/src/hooks/useStacApi.ts
+++ b/src/hooks/useStacApi.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import StacApi, { SearchMode } from '../stac-api';
 import { Link } from '../types/stac';
@@ -13,8 +14,9 @@ type StacApiHook = {
 
 function useStacApi(url: string, options?: GenericObject): StacApiHook {
   const { data, isSuccess, isLoading, isError } = useQuery({
-    queryKey: generateStacApiQueryKey(url, options),
+    queryKey: generateStacApiQueryKey(url),
     queryFn: async () => {
+      // Inspect STAC API for supported search modes
       const response = await fetch(url, {
         headers: {
           ...options?.headers,
@@ -26,11 +28,29 @@ function useStacApi(url: string, options?: GenericObject): StacApiHook {
         ({ rel, method }: Link) => rel === 'search' && method === 'POST'
       );
 
-      return new StacApi(response.url, doesPost ? SearchMode.POST : SearchMode.GET, options);
+      return {
+        mode: doesPost ? SearchMode.POST : SearchMode.GET,
+        url: response.url,
+      };
     },
     staleTime: Infinity,
   });
-  return { stacApi: isSuccess ? data : undefined, isLoading, isError };
+
+  return useMemo(() => {
+    if (isSuccess) {
+      return {
+        stacApi: new StacApi(data.url, data.mode, options),
+        isLoading,
+        isError,
+      };
+    }
+
+    return {
+      stacApi: undefined,
+      isLoading,
+      isError,
+    };
+  }, [data, isSuccess, isLoading, isError, options]);
 }
 
 export default useStacApi;

--- a/src/utils/queryKeys.test.ts
+++ b/src/utils/queryKeys.test.ts
@@ -50,37 +50,16 @@ describe('Query Key Generators', () => {
   });
 
   describe('generateStacApiQueryKey', () => {
-    it('should generate key with URL only when no options', () => {
+    it('should generate key with URL', () => {
       const url = 'https://example.com/stac';
       const key = generateStacApiQueryKey(url);
-      expect(key).toEqual(['stacApi', url, undefined]);
+      expect(key).toEqual(['stacApi', url]);
     });
 
-    it('should extract only headers from options', () => {
-      const url = 'https://example.com/stac';
-      const options = {
-        headers: { Authorization: 'Bearer token123' },
-        someOtherField: { deeply: { nested: { object: 'value' } } },
-        anotherField: 'ignored',
-      };
-      const key = generateStacApiQueryKey(url, options);
-      expect(key).toEqual(['stacApi', url, { headers: { Authorization: 'Bearer token123' } }]);
-    });
-
-    it('should handle options without headers', () => {
-      const url = 'https://example.com/stac';
-      const options = {
-        someField: 'value',
-        anotherField: { nested: 'data' },
-      };
-      const key = generateStacApiQueryKey(url, options);
-      expect(key).toEqual(['stacApi', url, undefined]);
-    });
-
-    it('should handle empty options object', () => {
-      const url = 'https://example.com/stac';
-      const key = generateStacApiQueryKey(url, {});
-      expect(key).toEqual(['stacApi', url, undefined]);
+    it('should generate distinct keys for different URLs', () => {
+      const key1 = generateStacApiQueryKey('https://example.com/a');
+      const key2 = generateStacApiQueryKey('https://example.com/b');
+      expect(key1).not.toEqual(key2);
     });
   });
 

--- a/src/utils/queryKeys.ts
+++ b/src/utils/queryKeys.ts
@@ -1,5 +1,4 @@
 import type { SearchRequestPayload, FetchRequest } from '../types/stac';
-import type { GenericObject } from '../types';
 
 /**
  * Extracts only the essential search parameters from a payload for query key generation.
@@ -63,15 +62,9 @@ export function generateItemQueryKey(url: string): [string, string] {
 
 /**
  * Generates a query key for STAC API initialization.
- * Extracts only the headers from options to avoid including large nested objects.
  */
-export function generateStacApiQueryKey(
-  url: string,
-  options?: GenericObject
-): [string, string, { headers: GenericObject } | undefined] {
-  // Only include headers in the query key, as other options don't affect the API initialization
-  const relevantOptions = options?.headers ? { headers: options.headers } : undefined;
-  return ['stacApi', url, relevantOptions];
+export function generateStacApiQueryKey(url: string): [string, string] {
+  return ['stacApi', url];
 }
 
 /**


### PR DESCRIPTION
Ensure that the STAC API does not refetch the root URL if options change (e.g. auth token refresh)

Based on @danielfdsilva's comment: https://github.com/developmentseed/stac-react/pull/56#issuecomment-4510404614