### PR TITLE
chore: scope npm publish to dist/ and rebuild before publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-example
-node_modules
-.github

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@developmentseed/stac-react",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "React components and hooks for building STAC-API front-ends",
   "repository": "git@github.com:developmentseed/stac-react.git",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -53,7 +53,11 @@
   "scripts": {
     "lint": "eslint .",
     "test": "jest",
-    "build": "tsc -b && vite build"
+    "build": "tsc -b && vite build",
+    "prepublishOnly": "rm -rf dist && yarn build"
   },
+  "files": [
+    "dist"
+  ],
   "packageManager": "yarn@4.10.3"
 }


### PR DESCRIPTION
## Summary
- Add a `files` allowlist so only `dist/` (plus npm-default `README.md`, `LICENSE`, `package.json`) is included in the published tarball.
- Add a `prepublishOnly` script that wipes `dist/` and rebuilds, so we never publish stale build outputs.
- The existing `.npmignore` becomes inert once `files` is set (npm prefers the allowlist). As such, we've removed `.npmignore`

Previously the published package shipped all of `src/` (including tests), top-level configs (`eslint.config.js`, `jest.config.cjs`, `vite.config.ts`, etc.), and any stale files left in `dist/` from prior builds.

## Impact

`npm pack --dry-run` before:
- 107 files
- 780 kB packed / 1.1 MB unpacked

After:
- 26 files
- 34.6 kB packed / 125.8 kB unpacked

## Notes
- `prepublishOnly` uses `rm -rf dist`, which is fine for the macOS/Linux dev + CI environment this repo targets.

## Test plan
- [x] `npm pack --dry-run` shows the expected 26-file tarball
- [x] CI checks pass